### PR TITLE
Bugfix/entity equip query slots

### DIFF
--- a/src/xeto/ph/entities.xeto
+++ b/src/xeto/ph/entities.xeto
@@ -331,9 +331,9 @@ Equip: Entity <abstract> {
   siteRef:      Ref
   spaceRef:     Ref?
   systemRef:    MultiRef?
-  parentEquips: Query<of:Equip, via:"equipRef+">                  // Equips that are referenced by this equip
-  childEquips:  Query<of:Equip, inverse:"ph::Equip.parentEquips"> // Equips that are referencing this equip
-  points:       Query<of:Point, inverse:"ph::Point.equips">       // Points contained by this equip
+  parentEquips: Query<of:Equip, via:"equipRef+">                  // Equips that are referenced by this equip and all parentEquips
+  childEquips:  Query<of:Equip, inverse:"ph::Equip.parentEquips"> // Equips that are referencing this equip and all childEquips
+  points:       Query<of:Point, inverse:"ph::Point.equips">       // Points that are referencing this equip and all childEquips
 }
 
 // Moving staircase used to move people between floors.
@@ -681,7 +681,7 @@ Point: Entity <abstract> {
   tz:            TimeZone?
   unit:          Unit?
   writable:      Marker?
-  equips:        Query<of:Equip, via:"equipRef+">  // Parent equips that contain this point
+  equips:        Query<of:Equip, via:"equipRef+">  // Equips that are referenced by this Point and all parentEquips
 }
 
 // Motor used with a pump to move fluid.

--- a/src/xeto/ph/entities.xeto
+++ b/src/xeto/ph/entities.xeto
@@ -331,9 +331,9 @@ Equip: Entity <abstract> {
   siteRef:      Ref
   spaceRef:     Ref?
   systemRef:    MultiRef?
-  parentEquips: Query<of:Equip, via:"equipRef+">                  // Returns all parentEquips of this equip
-  childEquips:  Query<of:Equip, inverse:"ph::Equip.parentEquips"> // Returns all childEquips of this equip
-  points:       Query<of:Point, inverse:"ph::Point.equips">       // Returns all childPoints of this equip
+  parentEquips: Query<of:Equip, via:"equipRef+">                  // Parent Equips that contain this Equip
+  childEquips:  Query<of:Equip, inverse:"ph::Equip.parentEquips"> // Child Equips contained by this Equip
+  points:       Query<of:Point, inverse:"ph::Point.equips">       // Child Points contained by this Equip
 }
 
 // Moving staircase used to move people between floors.
@@ -681,7 +681,7 @@ Point: Entity <abstract> {
   tz:            TimeZone?
   unit:          Unit?
   writable:      Marker?
-  equips:        Query<of:Equip, via:"equipRef+">  // Returns all parentEquips of this point
+  equips:        Query<of:Equip, via:"equipRef+">  // Parent Equips that contain this Point
 }
 
 // Motor used with a pump to move fluid.

--- a/src/xeto/ph/entities.xeto
+++ b/src/xeto/ph/entities.xeto
@@ -3,6 +3,9 @@
 // Licensed under the Academic Free License version 3.0
 // Auto-generated 15-Mar-2025
 //
+//  History:
+//    2025-06-14 Adam Garnhart - Bug Fixes for equip queries
+//
 
 // AC Electricity meter.
 // See `docHaystack::Meters` chapter.
@@ -328,8 +331,8 @@ Equip: Entity <abstract> {
   siteRef:      Ref
   spaceRef:     Ref?
   systemRef:    MultiRef?
-  parentEquips: Query<of:Point, via:"equipRef+">                  // Parent equips that contain this point
-  childEquips:  Query<of:Point, inverse:"ph::Equip.parentEquips"> // Sub-equips contained by this equip
+  parentEquips: Query<of:Equip, via:"equipRef+">                  // Equips that are referenced by this equip
+  childEquips:  Query<of:Equip, inverse:"ph::Equip.parentEquips"> // Equips that are referencing this equip
   points:       Query<of:Point, inverse:"ph::Point.equips">       // Points contained by this equip
 }
 

--- a/src/xeto/ph/entities.xeto
+++ b/src/xeto/ph/entities.xeto
@@ -4,7 +4,7 @@
 // Auto-generated 15-Mar-2025
 //
 //  History:
-//    2025-06-14 Adam Garnhart - Bug Fixes for equip queries
+//    2025-06-14 Adam Garnhart - Bug Fixes for Equip queries
 //
 
 // AC Electricity meter.
@@ -331,9 +331,9 @@ Equip: Entity <abstract> {
   siteRef:      Ref
   spaceRef:     Ref?
   systemRef:    MultiRef?
-  parentEquips: Query<of:Equip, via:"equipRef+">                  // Equips that are referenced by this equip and all parentEquips
-  childEquips:  Query<of:Equip, inverse:"ph::Equip.parentEquips"> // Equips that are referencing this equip and all childEquips
-  points:       Query<of:Point, inverse:"ph::Point.equips">       // Points that are referencing this equip and all childEquips
+  parentEquips: Query<of:Equip, via:"equipRef+">                  // Returns all parentEquips of this equip
+  childEquips:  Query<of:Equip, inverse:"ph::Equip.parentEquips"> // Returns all childEquips of this equip
+  points:       Query<of:Point, inverse:"ph::Point.equips">       // Returns all childPoints of this equip
 }
 
 // Moving staircase used to move people between floors.
@@ -681,7 +681,7 @@ Point: Entity <abstract> {
   tz:            TimeZone?
   unit:          Unit?
   writable:      Marker?
-  equips:        Query<of:Equip, via:"equipRef+">  // Equips that are referenced by this Point and all parentEquips
+  equips:        Query<of:Equip, via:"equipRef+">  // Returns all parentEquips of this point
 }
 
 // Motor used with a pump to move fluid.


### PR DESCRIPTION
- I noticed while using Equip and Point spec slot queries that things were not working correctly. (returning points instead of equips for the equip queries.)

- Edits to the Equip spec Query slots to correct the bugs causing the parentEquips and childEquips queries to behave incorrectly. (Equip queries were returning points instead of equips.)
- Additionally edited Point spec slot 'equips' to return all parent equips as expected (equipRef+ instead of equipRef)
 
- Updated code comments.